### PR TITLE
refactored to show how to use @Configruation to load multiple apis

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,1 @@
-inversionVersion=0.6.20-SNAPSHOT
+inversionVersion=0.6.20

--- a/src/main/java/me/repackage/ApiMain.java
+++ b/src/main/java/me/repackage/ApiMain.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) 2015-2018 Rocket Partners, LLC
+ * https://github.com/inversion-api
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package me.repackage;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+import io.inversion.cloud.service.spring.config.EnableInversion;
+
+/**
+ * Quick start example to wire up and run a REST API  
+ * that exposes relational db tables as REST collections.
+ * 
+ * See https://github.com/inversion-api/inversion-engine for full configuration options.
+ *      
+ */
+
+@SpringBootApplication
+@EnableInversion
+public class ApiMain
+{
+   public static void main(String[] args)
+   {
+      SpringApplication.run(ApiMain.class, args);
+   }
+}

--- a/src/main/java/me/repackage/MockApi.java
+++ b/src/main/java/me/repackage/MockApi.java
@@ -1,0 +1,29 @@
+package me.repackage;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import io.inversion.cloud.action.misc.MockAction;
+import io.inversion.cloud.model.Api;
+import io.inversion.cloud.model.JSNode;
+
+@Configuration
+public class MockApi
+{
+   @Bean
+   public static Api buildMockApi1()
+   {
+      return new Api()//
+                      .withName("secondApi")//
+                      .withEndpoint("GET", "*", new MockAction().withJson(new JSNode("hello_world", "from mock api one")));
+   }
+
+   @Bean
+   public static Api buildMockApi2()
+   {
+      return new Api()//
+                      .withName("thirdApi")//
+                      .withEndpoint("GET", "*", new MockAction().withJson(new JSNode("hello_world", "from mock api two")));
+   }
+
+}

--- a/src/main/java/me/repackage/NorthwindApi.java
+++ b/src/main/java/me/repackage/NorthwindApi.java
@@ -1,20 +1,7 @@
-/*
- * Copyright (c) 2015-2018 Rocket Partners, LLC
- * https://github.com/inversion-api
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- * 
- * http://www.apache.org/licenses/LICENSE-2.0
- * 
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package me.repackage;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
 
 import io.inversion.cloud.action.misc.MockAction;
 import io.inversion.cloud.action.rest.RestAction;
@@ -27,43 +14,30 @@ import io.inversion.cloud.model.Request;
 import io.inversion.cloud.model.Response;
 import io.inversion.cloud.service.Chain;
 import io.inversion.cloud.service.Engine;
-import io.inversion.cloud.service.spring.InversionApp;
 
-/**
- * Quick start example to wire up and run a REST API  
- * that exposes relational db tables as REST collections.
- * 
- * See https://github.com/inversion-api/inversion-engine for full configuration options.
- *      
- */
-public class MySpringBootApiMain
+@Configuration
+public class NorthwindApi
 {
-
-   public static void main(String[] args) throws Exception
-   {
-      InversionApp.run(buildApi());
-   }
-
+   @Bean
    /**
     * Constructs a REST API that exposes database tables and REST collections. 
     */
    public static Api buildApi()
    {
-      return new Api()
-                      //.withName("northwind")
+      return new Api().withName("northwind")
                       //
                       //-- if you give your api a name or an apiCode, it will become a required part of your url path structure...
                       //-- http://host[:port]/[Engine.servletMapping]/[Api.apiCode]/[Endpoint.path]/[collectionKey]/[entityKey]/[subCollecitonKey]
                       //-- 
-                      //-- In this case we are not using a servlet mapping and the api name/code is null so 
-                      //-- we will be able to browse our db tables and custom actions without those path components
+                      //-- In this case we are not using a servlet mapping and the api name/code "northwind" null so 
+                      //-- we will be able to browse our db tables and custom actions here:
                       //-- 
-                      //--  - http://localhost:8080/categories
-                      //--  - http://localhost:8080/orders
-                      //--  - http://localhost:8080/orderdetails
-                      //--  - http://localhost:8080/products
-                      //--  - http://localhost:8080/mock1
-                      //--  - http://localhost:8080/custom1
+                      //--  - http://localhost:8080/northwind/categories
+                      //--  - http://localhost:8080/northwind/orders
+                      //--  - http://localhost:8080/northwind/orderdetails
+                      //--  - http://localhost:8080/northwind/products
+                      //--  - http://localhost:8080/northwind/mock1
+                      //--  - http://localhost:8080/northwind/custom1
 
                       //-- DATABASE CONFIGURATION OPTION #1.
                       //-- you can set your database connection information explicitly in the code here... 
@@ -95,7 +69,7 @@ public class MySpringBootApiMain
                       //--  myDb.pass=${YOUR_JDBC_PASSWORD
 
                       .withEndpoint(new Endpoint("GET,PUT,POST,DELETE", "/*", new RestAction()).withExcludePaths("mock1/*,custom1/*"))//
-                      .withEndpoint("GET", "mock1/*", new MockAction().withJson(new JSNode("hello", "world")))//
+                      .withEndpoint("GET", "mock1/*", new MockAction().withJson(new JSNode("hello_world", "from northwind api")))//
                       .withEndpoint("GET", "custom1/*", new Action()
                          {
                             @Override


### PR DESCRIPTION
@lukasbradley et al.  I made the Engine constructor accept an Api varargs array and created multiple API config files that I annotated with @Configuration.   SB loaded them all up as I had hoped.

I think this approach will make it much easier and cleaner to work on multiple orchestrators in a single project.  This way each orchestrator can be its own API and configured it its own @Configuration annotated class.

Thoughts?